### PR TITLE
Distinguish between user id and username

### DIFF
--- a/ost-bot/src/i18n.ts
+++ b/ost-bot/src/i18n.ts
@@ -45,7 +45,8 @@ export const english: Readonly<Response> = {
 		`Streams length: ${beatmap.streams_length} (${beatmap.longest_stream}) | ` +
 		`Streams density: ${beatmap.streams_density} | Streams spacing: ${beatmap.streams_spacing} | ` +
 		`${beatmap.difficulty_rating} ★ | AR: ${beatmap.approach_rate} | OD: ${beatmap.accuracy} | ` +
-		`CS: ${beatmap.circle_size} | Length: ${formatLength(beatmap.length)}`,
+		`CS: ${beatmap.circle_size} | Length: ${formatLength(beatmap.length)} | ` +
+		`95%: ${beatmap.performance_95}PP | 100%: ${beatmap.performance_100}PP`,
 	requestNotFound:
 		'No beatmaps found that match provided filters, reduce the number of filters or change their values',
 	simpleRequest: (beatmap: Beatmap) =>
@@ -53,7 +54,8 @@ export const english: Readonly<Response> = {
 		`BPM: ${beatmap.bpm} | Streams length: ${beatmap.streams_length} (${beatmap.longest_stream}) | ` +
 		`Streams density: ${beatmap.streams_density} | Streams spacing: ${beatmap.streams_spacing} | ` +
 		`${beatmap.difficulty_rating} ★ | AR: ${beatmap.approach_rate} | OD: ${beatmap.accuracy} | ` +
-		`CS: ${beatmap.circle_size} | Duration: ${formatLength(beatmap.length)}`,
+		`CS: ${beatmap.circle_size} | Duration: ${formatLength(beatmap.length)} | ` +
+		`95%: ${beatmap.performance_95}PP | 100%: ${beatmap.performance_100}PP`,
 	simpleRequestNotFound:
 		'Beatmap analysis is only available for ranked beatmaps or beatmaps that are part of the collection',
 	unexpectedError: `The bot failed unexpectedly, please report this error via [${process.env.DISCORD_URL} Discord]`,
@@ -75,7 +77,8 @@ export const spanish: Readonly<Response> = {
 		`Longitud de streams: ${beatmap.streams_length} (${beatmap.longest_stream}) | ` +
 		`Densidad de streams: ${beatmap.streams_density} | Espaciado de streams: ${beatmap.streams_spacing} | ` +
 		`${beatmap.difficulty_rating} ★ | AR: ${beatmap.approach_rate} | OD: ${beatmap.accuracy} | ` +
-		`CS: ${beatmap.circle_size} | Duración: ${formatLength(beatmap.length)}`,
+		`CS: ${beatmap.circle_size} | Duración: ${formatLength(beatmap.length)} | ` +
+		`95%: ${beatmap.performance_95}PP | 100%: ${beatmap.performance_100}PP`,
 	requestNotFound:
 		'No se encontraron mapas que coinciden con los filtros suministrados, reduzca el número de filtros o cambie sus valores',
 	simpleRequest: (beatmap: Beatmap) =>
@@ -83,7 +86,8 @@ export const spanish: Readonly<Response> = {
 		`BPM: ${beatmap.bpm} | Longitud de streams: ${beatmap.streams_length} (${beatmap.longest_stream}) | ` +
 		`Densidad de streams: ${beatmap.streams_density} | Espaciado de streams: ${beatmap.streams_spacing} | ` +
 		`${beatmap.difficulty_rating} ★ | AR: ${beatmap.approach_rate} | OD: ${beatmap.accuracy} | ` +
-		`CS: ${beatmap.circle_size} | Duración: ${formatLength(beatmap.length)}`,
+		`CS: ${beatmap.circle_size} | Duración: ${formatLength(beatmap.length)} | ` +
+		`95%: ${beatmap.performance_95}PP | 100%: ${beatmap.performance_100}PP`,
 	simpleRequestNotFound:
 		'El análisis de mapas solo está disponible para mapas clasificados o mapas que sean parte de la colección',
 	unexpectedError: `El bot falló inesperadamente, por favor reporte este error vía [${process.env.DISCORD_URL} Discord]`,

--- a/ost-server/src/routes/bot.rs
+++ b/ost-server/src/routes/bot.rs
@@ -117,7 +117,7 @@ async fn retrieve_language(
             .await?;
         Ok(user.language)
     } else {
-        let language = if let Some(user) = osu_api.retrieve_user(username.clone()).await? {
+        let language = if let Some(user) = osu_api.retrieve_user(username.clone(), true).await? {
             parse_country_code(user.country_code)
         } else {
             String::from("en")
@@ -142,7 +142,7 @@ async fn update_language(
     Json(payload): Json<UserLanguage>,
     Path(username): Path<String>,
 ) -> ServerResult<impl IntoResponse> {
-    if let Some(user) = osu_api.retrieve_user(payload.id).await? {
+    if let Some(user) = osu_api.retrieve_user(payload.id, false).await? {
         let new_username = user.username.replace(' ', "_");
         if new_username != username {
             return Ok(StatusCode::FORBIDDEN);

--- a/ost-utils/src/beatmaps_processor/mod.rs
+++ b/ost-utils/src/beatmaps_processor/mod.rs
@@ -96,6 +96,7 @@ fn round_decimal(decimals: i32, number: f64) -> f32 {
 mod tests {
     use super::{Beatmap, ModDecimal, ModInteger};
     use crate::beatmaps_processor::process_beatmap;
+    use std::error::Error;
     use tokio::fs;
 
     fn compare_beatmaps(beatmap: Beatmap, test_beatmap: Beatmap) {
@@ -134,10 +135,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_process_beatmap() {
-        let beatmap = process_beatmap(&fs::read("./test_files/test.osu").await.unwrap())
-            .await
-            .unwrap();
+    async fn test_process_beatmap() -> Result<(), Box<dyn Error>> {
+        let beatmap = process_beatmap(&fs::read("./test_files/test.osu").await?).await?;
         let test_beatmap = Beatmap {
             accuracy: ModDecimal::new(1, 11.1, 10.0),
             approach_rate: ModDecimal::new(1, 11.0, 10.0),
@@ -153,12 +152,11 @@ mod tests {
             total_length: 211,
         };
         compare_beatmaps(beatmap, test_beatmap);
+        Ok(())
     }
     #[tokio::test]
-    async fn test_no_streams() {
-        let beatmap = process_beatmap(&fs::read("./test_files/test_no_streams.osu").await.unwrap())
-            .await
-            .unwrap();
+    async fn test_no_streams() -> Result<(), Box<dyn Error>> {
+        let beatmap = process_beatmap(&fs::read("./test_files/test_no_streams.osu").await?).await?;
         let test_beatmap = Beatmap {
             accuracy: ModDecimal::new(1, 7.1, 4.0),
             approach_rate: ModDecimal::new(1, 7.7, 5.0),
@@ -174,5 +172,6 @@ mod tests {
             total_length: 258,
         };
         compare_beatmaps(beatmap, test_beatmap);
+        Ok(())
     }
 }

--- a/ost-utils/src/storage/mod.rs
+++ b/ost-utils/src/storage/mod.rs
@@ -63,18 +63,19 @@ impl Client {
 mod tests {
     use crate::storage::Client;
     use dotenv::dotenv;
-    use std::fs;
+    use std::{error::Error, fs};
 
     const TEST_FILE: &str = "test.osu";
 
     #[tokio::test]
-    async fn test_storage() {
+    async fn test_storage() -> Result<(), Box<dyn Error>> {
         dotenv().ok();
-        let client = Client::from_environment().await.unwrap();
-        let file_content = fs::read("./test_files/test.osu").unwrap();
+        let client = Client::from_environment().await?;
+        let file_content = fs::read("./test_files/test.osu")?;
         assert!(client.upload(&file_content, TEST_FILE).await.is_ok());
-        assert_eq!(client.retrieve(TEST_FILE).await.unwrap(), file_content);
+        assert_eq!(client.retrieve(TEST_FILE).await?, file_content);
         assert!(client.delete(TEST_FILE).await.is_ok());
         assert!(client.retrieve(TEST_FILE).await.is_err());
+        Ok(())
     }
 }


### PR DESCRIPTION
Changes:

- User retrieval for the osu! API client did not distinguish between username and user id, resulting in confusing users with integer-only usernames. 
- Included the performance points to the request and analysis commands for the bot.